### PR TITLE
Fixed wasm test execution in CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -23,4 +23,4 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Run wasm tests
-      run: wasm-pack test --node ./cf-ddns-worker
+      run: wasm-pack test --node ./cf-ddns-worker --verbose

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -17,6 +17,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
     - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ resolver = "2"
 authors = ["Adam Sasine <adam.sasine@gmail.com>"]
 description = "Dynamic DNS using Cloudflare"
 edition = "2021"
+# 1.81 is required to mitigate a Cloudflare Workers bug (and subsequent wasm-bindgen bug)
+# https://github.com/cloudflare/workers-rs/issues/658
 rust-version = "1.81"
 homepage = "https://github.com/asasine/cf-ddns"
 repository = "https://github.com/asasine/cf-ddns.git"

--- a/cf-ddns-worker/README.md
+++ b/cf-ddns-worker/README.md
@@ -9,12 +9,6 @@ Developing this worker uses the [Rust support for Cloudflare Workers](https://de
 npx wrangler dev
 ```
 
-If you fail to start the local server with an uncaught link error, try overridding the Rust version to `1.81` ([ref](https://github.com/cloudflare/workers-rs/issues/658)):
-
-```bash
-rustup override set 1.81
-```
-
 ### Test
 Testing is done using wasm-bindgen-test ([ref](https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/usage.html)):
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+# 1.81 is required to mitigate a Cloudflare Workers bug (and subsequent wasm-bindgen bug)
+# https://github.com/cloudflare/workers-rs/issues/658
+channel = "1.81.0"
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
Required adding a [rustup toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) and explicitly setting up Rust in the CI runner in order to use the correct Rust version to accommodate cloudflare/workers-rs#658 and rustwasm/wasm-bindgen#4211

Fixes #6 